### PR TITLE
Add privacy-related pages

### DIFF
--- a/app/templates/app/aviso_privacidad.html
+++ b/app/templates/app/aviso_privacidad.html
@@ -1,0 +1,32 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Aviso de Privacidad - Aluminios del Sureste</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'app/index.css' %}">
+</head>
+<body>
+    <div class="container py-5">
+        <h1 class="mb-4">Aviso de Privacidad</h1>
+        <p>En cumplimiento del Reglamento (UE) 2016/679 General de Protección de Datos (RGPD) y la Ley Orgánica 3/2018 de Protección de Datos Personales y garantía de los derechos digitales (LOPDGDD), le informamos de lo siguiente:</p>
+        <h2>Responsable</h2>
+        <p>Aluminios del Sureste, Calle Azorín 44, Aspe, Alicante. Email: <a href="mailto:alusur1@gmail.com">alusur1@gmail.com</a></p>
+        <h2>Finalidad</h2>
+        <p>Los datos personales que nos facilite serán utilizados únicamente para responder a sus consultas y, en su caso, para la prestación de los servicios solicitados.</p>
+        <h2>Legitimación</h2>
+        <p>Tratamos sus datos sobre la base de su consentimiento expreso al enviarnos el formulario de contacto o al comunicarse con nosotros.</p>
+        <h2>Destinatarios</h2>
+        <p>No se cederán datos a terceros, salvo obligación legal.</p>
+        <h2>Derechos</h2>
+        <p>Puede ejercer sus derechos de acceso, rectificación, supresión, oposición, portabilidad y limitación enviando un correo a <a href="mailto:alusur1@gmail.com">alusur1@gmail.com</a>.</p>
+        <p>Si considera que el tratamiento de sus datos no se ajusta a la normativa vigente, puede presentar una reclamación ante la Agencia Española de Protección de Datos.</p>
+    </div>
+    {% include 'app/includes/footer.html' %}
+    {% include 'app/includes/scripts.html' %}
+</body>
+</html>

--- a/app/templates/app/includes/footer.html
+++ b/app/templates/app/includes/footer.html
@@ -129,9 +129,9 @@
                     </div>
                     <div class="col-md-6">
                         <div class="footer-links-bottom">
-                            <a href="#" class="footer-link-bottom">Política de Privacidad</a>
-                            <a href="#" class="footer-link-bottom">Términos de Servicio</a>
-                            <a href="#" class="footer-link-bottom">Cookies</a>
+                            <a href="{% url 'aviso_privacidad' %}" class="footer-link-bottom">Política de Privacidad</a>
+                            <a href="{% url 'terminos_servicio' %}" class="footer-link-bottom">Términos de Servicio</a>
+                            <a href="{% url 'politica_cookies' %}" class="footer-link-bottom">Cookies</a>
                             <!-- Acceso admin discreto -->
                             <a href="{% url 'admin_login' %}" class="footer-link-bottom admin-access bg-primary rounded p-2" title="Panel de administración">Admin</a>
                         </div>

--- a/app/templates/app/politica_cookies.html
+++ b/app/templates/app/politica_cookies.html
@@ -1,0 +1,25 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Política de Cookies - Aluminios del Sureste</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'app/index.css' %}">
+</head>
+<body>
+    <div class="container py-5">
+        <h1 class="mb-4">Política de Cookies</h1>
+        <p>Este sitio web utiliza cookies propias y de terceros para mejorar su experiencia y realizar análisis estadísticos. Al navegar por nuestro sitio, usted acepta el uso de cookies.</p>
+        <h2>¿Cómo deshabilitar las cookies?</h2>
+        <p>Puede eliminar o bloquear las cookies desde la configuración de su navegador. Consulte la ayuda del mismo para obtener más información.</p>
+        <h2>Cookies utilizadas</h2>
+        <p>Utilizamos cookies técnicas necesarias para el funcionamiento de la web y cookies de análisis de Google Analytics para obtener datos estadísticos anónimos.</p>
+    </div>
+    {% include 'app/includes/footer.html' %}
+    {% include 'app/includes/scripts.html' %}
+</body>
+</html>

--- a/app/templates/app/terminos_servicio.html
+++ b/app/templates/app/terminos_servicio.html
@@ -1,0 +1,27 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Términos de Servicio - Aluminios del Sureste</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'app/index.css' %}">
+</head>
+<body>
+    <div class="container py-5">
+        <h1 class="mb-4">Términos de Servicio</h1>
+        <p>El acceso y uso de este sitio web están sujetos a los siguientes términos. Al navegar por él, usted acepta estas condiciones.</p>
+        <h2>Responsabilidad</h2>
+        <p>Aluminios del Sureste no se hace responsable de los daños derivados del uso de la información de este sitio.</p>
+        <h2>Propiedad intelectual</h2>
+        <p>Todos los contenidos son propiedad de Aluminios del Sureste o de sus respectivos titulares y están protegidos por la normativa de propiedad intelectual.</p>
+        <h2>Modificaciones</h2>
+        <p>Nos reservamos el derecho de modificar estos términos en cualquier momento. Se considerarán vigentes desde su publicación en la web.</p>
+    </div>
+    {% include 'app/includes/footer.html' %}
+    {% include 'app/includes/scripts.html' %}
+</body>
+</html>

--- a/app/urls.py
+++ b/app/urls.py
@@ -28,6 +28,9 @@ urlpatterns = [
     path('admin/presentacion/', views.admin_presentacion, name='admin_presentacion'),
     path('admin/servicios/', views.admin_servicios, name='admin_servicios'),
     path('admin/proyectos/', views.admin_proyectos, name='admin_proyectos'),
+    path('aviso-privacidad/', views.aviso_privacidad, name='aviso_privacidad'),
+    path('politica-cookies/', views.politica_cookies, name='politica_cookies'),
+    path('terminos-servicio/', views.terminos_servicio, name='terminos_servicio'),
     
     # Vistas AJAX para modales
     # Vistas AJAX para modales

--- a/app/views.py
+++ b/app/views.py
@@ -378,3 +378,15 @@ def servicio_detalle(request, pk):
 def proyecto_detalle(request, pk):
     proyecto = get_object_or_404(ProyectoFinalizado, pk=pk)
     return render(request, "app/proyecto_detalle.html", {"proyecto": proyecto})
+
+def aviso_privacidad(request):
+    """Página de aviso de privacidad"""
+    return render(request, "app/aviso_privacidad.html")
+
+def politica_cookies(request):
+    """Página de política de cookies"""
+    return render(request, "app/politica_cookies.html")
+
+def terminos_servicio(request):
+    """Página de términos de servicio"""
+    return render(request, "app/terminos_servicio.html")


### PR DESCRIPTION
## Summary
- add a cookies policy page
- add a terms-of-service page
- route new views and link from footer

## Testing
- `pip install -r requirements.txt`
- `python manage.py check` *(fails: Cloudinary not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6841b86e8bc48328ba942c4be53b6a9b